### PR TITLE
Replaces log4j with slf4j-simple and adds section for building native-image with GraalVM to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,45 @@ Command line options are:
      -n,--num <arg>    Number of tables to be generated.
      -t,--type <arg>   Type of test file. Either sql or dot.
 
+## Native-image build with GraalVM
+
+If you want to leverage [GraalVM's](https://www.graalvm.org/) capability to build 
+[native-images](https://www.graalvm.org/latest/reference-manual/native-image/), 
+you can do so by following the below steps:
+
+- [Install GraalVM](https://www.graalvm.org/latest/docs/getting-started/#install-graalvm) on your system.
+- [Install the native-image](https://www.graalvm.org/latest/docs/getting-started/#native-image) functionality of `GraalVM`.
+- Depending on your OS, the linker might require `libfreetype.a` during the native-image build of this project;
+  in my case (Ubuntu 20.04) I did it via `sudo apt-get install libfreetype6-dev`.
+- If not already done, clone this project with `git`.
+- Add the driver of the database you want to build this native-image for to the dependency list in `pom.xml`.
+  E.g. for `PostgreSQL` I added:
+  ```
+  <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.3.0</version>
+  </dependency>
+  ```
+- From the root folder of the project build the app as usual with `mvn clean install`
+- Now, we will execute the application as we usually would, but with an agent attached 
+  that collects configurations for the native-image build and puts into the right folder:
+  ```
+  java -agentlib:native-image-agent=config-output-dir=app/src/main/resources/META-INF/native-image -jar app/target/dbvisualizer-app-1.0.0-SNAPSHOT-jar-with-dependencies.jar -driver org.postgresql.Driver -a PLANT -o app/target/postgresql_test.puml -d PostgreSQL -u <USER> -p <PASSWORD> -url <JDBC_URL> -r app/target/postgresql_test.html
+  ```
+  You will be able to see the files in `app/src/main/resources/META-INF/native-image`.
+- We run `mvn clean install` again. The first time we did it was just for being able to 
+  collect the required configurations. Now we build the app including the configurations. 
+- Switch into the target folder: `cd app/target`
+- Next, create the native-image from the jar we just built by executing:
+  ```
+  native-image -jar dbvisualizer-app-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+  ```
+- To finally run the native-image, execute:
+  ```
+  ./dbvisualizer-app-1.0.0-SNAPSHOT-jar-with-dependencies -driver org.postgresql.Driver -a PLANT -o ../postgresql_test.puml -d PostgreSQL -u <USER> -p <PASSWORD> -url <JDBC_URL> -r ../postgresql_test.html
+  ```
+
 ## Ideas for future enhancements
 
 List of some features, which might be added in the future:

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -12,9 +12,6 @@
 	<name>DB Visualizer App</name>
 
 	<description>Creates a dot graph description from a database schema using JDBC</description>
-	<properties>
-		<log4j.version>2.19.0</log4j.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -45,23 +42,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.36</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j.version}</version>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.vandeseer</groupId>

--- a/app/src/main/resources/log4j2.properties
+++ b/app/src/main/resources/log4j2.properties
@@ -1,6 +1,0 @@
-appender.console.type = Console
-appender.console.name = STDOUT
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{DEFAULT} %level %m%n
-rootLogger.level = debug
-rootLogger.appenderRef.stdout.ref = STDOUT

--- a/app/src/main/resources/simplelogger.properties
+++ b/app/src/main/resources/simplelogger.properties
@@ -1,0 +1,3 @@
+# https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
+
+org.slf4j.simpleLogger.defaultLogLevel=debug


### PR DESCRIPTION
As discussed in #12

Please note: 
Since I'm no graalvm native-image expert, there might be ways to improve this process I described, but maybe it's good enough for a start.
As I already mentioned in the issue, the biggest trade-off for me is that one has to add the database driver to the dependency list... not sure if that can be done better or if that is a natural limitation of native images not being able to load jar files. I just don't know.